### PR TITLE
Fix check for when empty

### DIFF
--- a/models/git_notes_publisher.rb
+++ b/models/git_notes_publisher.rb
@@ -70,7 +70,7 @@ class GitNotesPublisher < Jenkins::Tasks::Publisher
 
   def sqs_configured?
     [sqs_queue, access_key, secret_key].all? do |i|
-      !i.nil? && !i.empty?
+      !i.nil? && !i.strip.empty?
     end
   end
 end

--- a/spec/models/git_notes_publisher_spec.rb
+++ b/spec/models/git_notes_publisher_spec.rb
@@ -60,6 +60,14 @@ describe GitNotesPublisher do
         end
       end
 
+      context 'when one is a whitespace string' do
+        let(:sqs_queue) { '  ' }
+
+        it 'should be false' do
+          expect(subject.send(:sqs_configured?)).to be_falsy
+        end
+      end
+
       context 'when all are valid' do
         let(:sqs_queue) { 'a' }
 


### PR DESCRIPTION
@bfulton 

This would return `true` when nothing was configured and the values were all `''`.
