### PR TITLE
Add NullListener to suppress nil exceptions when listener lookup is unsu...

### DIFF
--- a/lib/build_participant.rb
+++ b/lib/build_participant.rb
@@ -1,8 +1,8 @@
 require 'stringio'
 
 class NullListener
-  def method_missing(*args, &block)
-    self
+  def method_missing(meth, *args, &block)
+    $stderr.puts "[#{meth}] - #{args.join(',')}"
   end
 end
 


### PR DESCRIPTION
...ccessful

@bfulton, please review.

Not sure where CI for this is meant to run. Travis? Ran specs locally and they passed.

Motivation: a recent build failure https://jenkins.swipely.com/view/app/job/app.service_performance_pipeline/lastFailedBuild/console

Relevant stack trace:
12:22:32.645 git-notes plugin: returning results of run: {:out=>"commit dcdf54d62b1aa1a56403e121f35f7a1da347b014\nMerge: 61f5d44 2d5d0c3\nAuthor: Peak Xu peak.xu@gmail.com\nDate:   Mon Oct 6 12:20:13 2014 -0400\n\n    Merge pull request #33 from dotswipely/deterministic_server_name\n    \n    Merge strings in aggregating hash in deterministic order\n\n", :err=>"", :val=>0}
12:22:33.398 ERROR: undefined method `info' for nil:NilClass (NoMethodError)
12:22:33.399 /var/lib/jenkins/plugins/git-notes/WEB-INF/classes/lib/build_participant.rb:29:in`info'
12:22:33.399 /var/lib/jenkins/plugins/git-notes/WEB-INF/classes/lib/build_participant.rb:58:in `run'
12:22:33.399 /var/lib/jenkins/plugins/git-notes/WEB-INF/classes/lib/git_updater.rb:37:in`push_notes'
12:22:33.399 /var/lib/jenkins/plugins/git-notes/WEB-INF/classes/lib/git_updater.rb:14:in `update!'
12:22:33.399 /var/lib/jenkins/plugins/git-notes/WEB-INF/classes/models/git_notes_publisher.rb:50:in`update_git_notes'
