### PR TITLE
Make build context non singleton

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/lib/build_context.rb
+++ b/lib/build_context.rb
@@ -1,24 +1,9 @@
-require 'singleton'
-
 class BuildContext
-  include Singleton
-
   attr_reader :build, :launcher, :listener
 
-  def set(build, launcher, listener, &block)
+  def initialize(build, launcher, listener, &block)
     @build = build
     @launcher = launcher
     @listener = listener
-    if block_given?
-      begin
-        block.call
-      ensure
-        unset
-      end
-    end
-  end
-
-  def unset
-    @build = @launcher = @listener = nil
   end
 end

--- a/lib/build_notes.rb
+++ b/lib/build_notes.rb
@@ -1,6 +1,12 @@
 class BuildNotes
   include BuildParticipant
 
+  attr_reader :build_context
+
+  def initialize(build_context)
+    @build_context = build_context
+  end
+
   def notes
     info "building new notes hash"
     native = build.send(:native)

--- a/lib/build_participant.rb
+++ b/lib/build_participant.rb
@@ -1,17 +1,12 @@
 require 'stringio'
 
+# This mixin provides utilities for interacting with a build context. Including
+# classes/modules must provide a `#build_context` method, which returns a
+# reference to the build context.
 module BuildParticipant
-  def build
-    BuildContext.instance.build
-  end
+  extend Forwardable
 
-  def launcher
-    BuildContext.instance.launcher
-  end
-
-  def listener
-    BuildContext.instance.listener
-  end
+  def_delegators :build_context, :build, :launcher, :listener
 
   def debug(line)
     listener.debug(format(line))

--- a/lib/git_updater.rb
+++ b/lib/git_updater.rb
@@ -3,6 +3,12 @@ class GitUpdater
 
   include BuildParticipant
 
+  attr_reader :build_context
+
+  def initialize(build_context)
+    @build_context = build_context
+  end
+
   def refname
     Constants::GIT_NOTES_REF
   end

--- a/lib/sqs_notifier.rb
+++ b/lib/sqs_notifier.rb
@@ -4,10 +4,11 @@ require 'fog'
 class SqsNotifier
   include BuildParticipant
 
-  attr_reader :queue_url, :creds
+  attr_reader :queue_url, :creds, :build_context
 
   # Create anew SqsNotifier with the given queue_url and credentials.
-  def initialize(queue_url, creds)
+  def initialize(build_context, queue_url, creds)
+    @build_context = build_context
     @queue_url = queue_url
     @creds = creds
   end

--- a/models/git_notes_publisher.rb
+++ b/models/git_notes_publisher.rb
@@ -32,40 +32,36 @@ class GitNotesPublisher < Jenkins::Tasks::Publisher
   # @param [Jenkins::Launcher] launcher the launcher that can run code on the node running this build
   # @param [Jenkins::Model::Listener] listener the listener for this build.
   def perform(build, launcher, listener)
-    BuildContext.instance.set(build, launcher, listener) do
-      notes = BuildNotes.new.notes
-      update_git_notes(notes)
-      notify_sqs(notes)
-    end
+    context = BuildContext.new(build, launcher, listener)
+    notes = BuildNotes.new(context).notes
+    update_git_notes(notes, context)
+    notify_sqs(notes, context)
   end
 
   private
 
-  def update_git_notes(notes)
-    git_updater = GitUpdater.new
+  def update_git_notes(notes, context)
+    git_updater = GitUpdater.new(context)
     retry_times = Constants::CONCURRENT_UPDATE_SLEEP_TIMES
     retry_times.each_with_index do |retry_time, idx|
       begin
-        info "updating git notes"
+        context.listener.info "updating git notes"
         git_updater.update!(notes)
         break
       rescue GitUpdater::ConcurrentUpdateError => ex
         retries = retry_times.length.pred - idx
         raise ex if retries.zero?
-        warn "caught ConcurrentUpdateError while updating git notes, retrying (#{retries}x left)"
+        context.listener.warn "caught ConcurrentUpdateError while updating git notes, retrying (#{retries}x left)"
         sleep(retry_time)
       end
     end
 
-    info "updated git notes: #{notes}"
+    context.listener.info "updated git notes: #{notes}"
   end
 
-  def notify_sqs(notes)
+  def notify_sqs(notes, context)
+    SqsNotifier.new(context, sqs_queue, aws_access_key_id: access_key, aws_secret_access_key: secret_key)
     queue.notify_note(notes) if sqs_configured?
-  end
-
-  def queue
-    @queue ||= SqsNotifier.new(sqs_queue, aws_access_key_id: access_key, aws_secret_access_key: secret_key)
   end
 
   def sqs_configured?

--- a/models/git_notes_publisher.rb
+++ b/models/git_notes_publisher.rb
@@ -6,8 +6,6 @@ require File.expand_path('../../lib/git_updater', __FILE__)
 require File.expand_path('../../lib/sqs_notifier', __FILE__)
 
 class GitNotesPublisher < Jenkins::Tasks::Publisher
-  include BuildParticipant
-
   display_name "Publish build result as git-notes"
 
   attr_reader :sqs_queue, :access_key, :secret_key

--- a/spec/lib/build_context_spec.rb
+++ b/spec/lib/build_context_spec.rb
@@ -1,47 +1,17 @@
 require 'spec_helper'
 
 describe BuildContext do
-  subject { BuildContext.instance }
-
   let(:build) { double(:build) }
   let(:launcher) { double(:launcher) }
   let(:listener) { double(:listener) }
 
-  before do
-    subject.unset
-  end
+  subject { BuildContext.new(build, launcher, listener) }
 
-  after do
-    subject.unset
-  end
-
-  context '.set' do
-    it 'sets the attributes' do
-      subject.set(build, launcher, listener)
+  describe '#initialize' do
+    it 'sets the build, launcher, and listener' do
       expect(subject.build).to eq(build)
       expect(subject.launcher).to eq(launcher)
       expect(subject.listener).to eq(listener)
-    end
-
-    it 'temporarily sets the attributes when passed a block' do
-      subject.set(build, launcher, listener) do
-        expect(subject.build).to eq(build)
-        expect(subject.launcher).to eq(launcher)
-        expect(subject.listener).to eq(listener)
-      end
-      expect(subject.build).to be_nil
-      expect(subject.launcher).to be_nil
-      expect(subject.listener).to be_nil
-    end
-  end
-
-  context '.unset' do
-    it 'unsets any previously set attributes' do
-      subject.set(build, launcher, listener)
-      subject.unset
-      expect(subject.build).to be_nil
-      expect(subject.launcher).to be_nil
-      expect(subject.listener).to be_nil
     end
   end
 end

--- a/spec/lib/build_notes_spec.rb
+++ b/spec/lib/build_notes_spec.rb
@@ -16,16 +16,11 @@ describe BuildNotes do
     )
   end
   let(:build) { double(:send => native) }
+  let(:context) { BuildContext.new(build, launcher, listener) }
 
-  before do
-    BuildContext.instance.set(build, launcher, listener)
-  end
+  subject { BuildNotes.new(context) }
 
-  after do
-    BuildContext.instance.unset
-  end
-
-  context '.notes' do
+  describe '.notes' do
     it 'returns a jenkins build note' do
       expect(subject.notes).to_not be_nil
     end

--- a/spec/lib/build_participant_spec.rb
+++ b/spec/lib/build_participant_spec.rb
@@ -8,21 +8,20 @@ describe BuildParticipant do
       double(:realpath => '/var/jenkins/builds')
     end
     let(:build) { double(:workspace => workspace) }
-
-    subject {
-      class MyBuildParticipant
+    let(:context) { BuildContext.new(build, launcher, listener) }
+    let(:test_class) {
+      Class.new do
         include BuildParticipant
+
+        attr_reader :build_context
+
+        def initialize(build_context)
+          @build_context = build_context
+        end
       end
-      MyBuildParticipant.new
     }
 
-    before do
-      BuildContext.instance.set(build, launcher, listener)
-    end
-
-    after do
-      BuildContext.instance.unset
-    end
+    subject { test_class.new(context) }
 
     context '.build' do
       it 'returns the build set in the context singleton' do

--- a/spec/lib/git_updater_spec.rb
+++ b/spec/lib/git_updater_spec.rb
@@ -22,16 +22,9 @@ describe GitUpdater do
       })
     end
     let(:build) { double(:send => native, :workspace => workspace) }
+    let(:context) { BuildContext.new(build, launcher, listener) }
 
-    subject { GitUpdater.new }
-
-    before do
-      BuildContext.instance.set(build, launcher, listener)
-    end
-
-    after do
-      BuildContext.instance.unset
-    end
+    subject { GitUpdater.new(context) }
 
     context '.fetch_notes' do
       it 'executes a command to fetch the latest notes' do
@@ -47,7 +40,7 @@ describe GitUpdater do
         expect(subject).to receive(:info).with('existing note: existing note')
         subject.show_notes
       end
-      
+
       it 'logs appropriately when there is no existing note' do
         expect(subject).to receive(:run).and_return({:val => 1, :out => 'an error'})
         expect(subject).to receive(:info)

--- a/spec/lib/sqs_notifier_spec.rb
+++ b/spec/lib/sqs_notifier_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 
 describe SqsNotifier do
-  subject { SqsNotifier.new('my-test-queue', {}) }
+  let(:context) { double(:context) }
+  subject { SqsNotifier.new(context, 'my-test-queue', {}) }
 
   describe '#notify_note' do
     let(:remote_command) { "git config --get remote.origin.url" }

--- a/spec/models/git_notes_publisher_spec.rb
+++ b/spec/models/git_notes_publisher_spec.rb
@@ -5,16 +5,10 @@ describe GitNotesPublisher do
     let(:build) { double(:build) }
     let(:launcher) { double(:launcher) }
     let(:listener) { double(:listener, :info => true) }
+    let(:context) { BuildContext.new(build, launcher, listener) }
     let(:git_updater) { double(:git_updater) }
 
-    before do
-      BuildNotes.stub(:new => double(:notes => {}))
-      BuildContext.instance.set(build, launcher, listener)
-    end
-
-    after do
-      BuildContext.instance.unset
-    end
+    before { BuildNotes.stub(:new => double(:notes => {})) }
 
     context '.perform' do
       before do


### PR DESCRIPTION
@adamjt @bfulton @tlunter 

We've run into issues when there are a lot of concurrent executors on the CI server because the global build context gets changed while tests are executing. This pull makes the build context a PORO, and passes it around as needed.